### PR TITLE
fix: get new token each time auth is run rather than just the class initialisation

### DIFF
--- a/.github/workflows/tag_on_merged.yml
+++ b/.github/workflows/tag_on_merged.yml
@@ -1,0 +1,124 @@
+name: Build & Auto-Release from main
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]        # Fire only for PRs targeting main
+
+permissions:
+  contents: write           # Needed to create tags and releases
+
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  build-tag-release:
+    # Run only when the PR was actually merged (not just closed)
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main (post-merge)
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0      # fetch all history & tags (needed for tagging)
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build wheel
+        run: python -m build
+
+      - name: Extract version from pyproject.toml
+        id: version
+        shell: bash
+        run: |
+          python - <<'PY' > .version
+          import pathlib, sys
+          try:
+              import tomllib  # Python 3.11+
+          except Exception as e:
+              sys.exit(f"tomllib not available: {e}")
+          data = tomllib.loads(pathlib.Path("pyproject.toml").read_text())
+          v = (data.get("project", {}).get("version")
+               or data.get("tool", {}).get("poetry", {}).get("version"))
+          if not v:
+              raise SystemExit("No version found in pyproject.toml (project.version or tool.poetry.version).")
+          print(v)
+          PY
+          echo "value=$(cat .version)" >> "$GITHUB_OUTPUT"
+
+      - name: Compute tag name (prefix with 'v')
+        id: tag
+        run: |
+          v="${{ steps.version.outputs.value }}"
+          if [[ "$v" != v* ]]; then tag="v$v"; else tag="$v"; fi
+          echo "value=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Determine wheel asset
+        id: wheel
+        run: |
+          w=$(ls -1 dist/*.whl | head -n 1)
+          if [[ -z "$w" ]]; then
+            echo "No wheel artifact found in dist/"
+            exit 1
+          fi
+          echo "path=$w" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git author (for tagging)
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Check if tag already exists (local or remote)
+        id: tag_exists
+        run: |
+          tag="${{ steps.tag.outputs.value }}"
+          # check local
+          if git rev-parse "$tag" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # check remote
+          git fetch --tags --force --prune
+          if git rev-parse "$tag" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push annotated tag
+        if: steps.tag_exists.outputs.exists == 'false'
+        run: |
+          tag="${{ steps.tag.outputs.value }}"
+          git tag -a "$tag" -m "Release $tag"
+          git push origin "$tag"
+
+      - name: Create or update GitHub Release and upload wheel
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ steps.tag.outputs.value }}"
+          wheel="${{ steps.wheel.outputs.path }}"
+          # Mark prereleases if version looks like a/b/rc (PEP 440-ish)
+          prerelease_flag=""
+          if [[ "$tag" =~ a[0-9]*$ || "$tag" =~ b[0-9]*$ || "$tag" =~ rc[0-9]*$ ]]; then
+            prerelease_flag="--prerelease"
+          fi
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "Release $tag exists; uploading asset (clobbering if present)."
+            gh release upload "$tag" "$wheel" --clobber
+          else
+            gh release create "$tag" "$wheel" \
+              --title "$tag" \
+              --generate-notes $prerelease_flag
+          fi

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ In fact, every time you pull down or refresh the project, it's worth running `uv
 If you're making changes to the library, here's what needs to happen for it to be available:
 
 ### New imported libraries 
-These are libraries required by scripts, which would normally be added to requirements.txt
+These are libraries required by scripts, which would normally be added to `requirements.txt`
 
 ```
 uv add LIBRARY_NAME==version.number
@@ -104,7 +104,9 @@ If a new function or component is available, please update files within the `doc
 
 ### Tagging the new version
 
-Next, it's a case of changing the `version` value in `pyproject.toml` so it matches the forthcoming tag - just for consistency.
+**Important** The `version` in `pyproject.toml` will be used as the release tag, so it's important to ensure this is updated.
+
+The standard [semver](https://semver.org/) formatting of the version should be used, without a 'v' prefix; this will be added in the Github Release.
 
 ### Validating the library on other projects
 
@@ -142,7 +144,7 @@ You can then run your script with `uv run python ...` or `source .venv/bin.activ
 
 ### Raising the PR and tagging the release
 
-Raise a PR once the library is fully validated, and once the PR has been merged, tag the release (this will soon be automatically done), and it will automatically create a release asset file that corresponds with the tag.
+Raise a PR once the library is fully validated, and once the PR has been merged, the release will be tagged automatically with the version in `pyproject.toml`.
 
 ### Refreshing the version in other repositories
 

--- a/README.md
+++ b/README.md
@@ -106,11 +106,47 @@ If a new function or component is available, please update files within the `doc
 
 Next, it's a case of changing the `version` value in `pyproject.toml` so it matches the forthcoming tag - just for consistency.
 
-Finally, once the PR has been merged, tag the release, and it will automatically create a release asset file that corresponds with the tag.
+### Validating the library on other projects
+
+The library is built into a [Python Wheel](https://discuss.python.org/t/where-the-name-wheel-comes-from/6708), which is then imported into projects that use it.
+The build taks place automatically when the release is tagged, so it's available as a release asset - more about this below.
+
+To validate the updated library, it needs to be built locally, and then imported into a project for validation. Here's how:
+
+#### Install the build tools and run the build
+
+```
+uv pip install build
+uv run python -m build
+
+* Building wheel...
+Successfully built hmpps_python_lib-0.1.2.tar.gz and hmpps_python_lib-0.1.2-py3-none-any.whl
+```
+
+This should build the wheel, and it can be found in the `dist` directory.
+
+#### Install the wheel in the project you want to validate
+
+Copy the wheel to the root directory of your project and run:
+
+```
+uv remove hmpps-python-lib
+uv add hmpps-python-lib@hmpps_python_lib-0.1.2-py3-none-any.whl
+uv sync
+```
+(substituting the version of the build above for the one you're evaluating)
+
+You can confirm that the version is correct by looking in the `.venv/lib/hmpps_python_lib-xxx.dist-info` directory for the library, and opening one of the updated files - you should see your changes.
+
+You can then run your script with `uv run python ...` or `source .venv/bin.activate && python ...` and check that it works.
+
+### Raising the PR and tagging the release
+
+Raise a PR once the library is fully validated, and once the PR has been merged, tag the release (this will soon be automatically done), and it will automatically create a release asset file that corresponds with the tag.
 
 ### Refreshing the version in other repositories
 
-If a tool is currently using the hmpps-python-lib library, updating is as simple as either editing the pyproject.toml file in the project's root directory
+If a tool is currently using the hmpps-python-lib library, updating is as simple as either editing the pyproject.toml file in the project's root directory:
 
 ```
 [tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hmpps-python-lib"           # distribution name (keeps hyphens)
-version = "0.1.2"
+version = "0.1.4"
 description = "HMPPS shared Python library"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hmpps-python-lib"           # distribution name (keeps hyphens)
-version = "0.1.0"
+version = "0.1.2"
 description = "HMPPS shared Python library"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/hmpps/clients/github.py
+++ b/src/hmpps/clients/github.py
@@ -270,7 +270,40 @@ class GithubSession:
     return summary
 
   def create_update_pr(self, request):
-    branch_name = f'REQ_{request["id"]}_{request.get("github_repo")}'
+    if request.get('request_type') == 'Archive':
+      log_info(f'Request type Archive for repository {request.get("github_repo")}')
+      branch_name = f'REQ_ARCHIVE_{request["id"]}_{request.get("github_repo")}'
+      json_fields = [
+        'request_type',
+        'github_org',
+        'github_repo',
+        'requester_name',
+        'requester_email',
+        'requester_team',
+      ]
+    else:
+      log_info(f'Request type Add for repository {request.get("github_repo")}')
+      branch_name = f'REQ_{request["id"]}_{request.get("github_repo")}'
+      json_fields = [
+        'request_type',
+        'github_repo',
+        'repo_description',
+        'base_template',
+        'jira_project_keys',
+        'github_project_visibility',
+        'product',
+        'github_project_teams_write',
+        'github_projects_teams_admin',
+        'github_project_branch_protection_restricted_teams',
+        'prod_alerts_severity_label',
+        'nonprod_alerts_severity_label',
+        'slack_channel_nonprod_release_notify',
+        'slack_channel_prod_release_notify',
+        'slack_channel_security_scans_notify',
+        'requester_name',
+        'requester_email',
+        'requester_team',
+      ]
 
     # If the branch doesn't exist - create it
     # This will obviously create a new PR even if one already exists
@@ -285,25 +318,6 @@ class GithubSession:
     request_json_file = f'{branch_name}.json'
 
     # Populate the json file only with useful stuff
-    json_fields = [
-      'github_repo',
-      'repo_description',
-      'base_template',
-      'jira_project_keys',
-      'github_project_visibility',
-      'product',
-      'github_project_teams_write',
-      'github_projects_teams_admin',
-      'github_project_branch_protection_restricted_teams',
-      'prod_alerts_severity_label',
-      'nonprod_alerts_severity_label',
-      'slack_channel_nonprod_release_notify',
-      'slack_channel_prod_release_notify',
-      'slack_channel_security_scans_notify',
-      'requester_name',
-      'requester_email',
-      'requester_team',
-    ]
 
     request_json = {key: request.get(key) for key in json_fields if key in request}
 
@@ -505,6 +519,34 @@ class GithubSession:
         )
         sys.exit(1)
 
+  def archive_repo(self, github_org, github_repo):
+    # Archive repository
+    # Headers for the request
+    headers = {
+      'Authorization': f'token {self.rest_token}',
+      'Accept': 'application/vnd.github.v3+json',
+    }
+
+    # Data for the request
+    data = {
+      'archived': True,
+    }
+
+    # Make the request to create a new repository from a template
+    response = requests.post(
+      f'https://api.github.com/repos/{github_org}/{github_repo}',
+      headers=headers,
+      json=data,
+    )
+
+    if response.status_code == 200:
+      log_info(f'Repository {github_repo} archived successfully.')
+    else:
+      log_error(
+        f'Failed to archive repository: {response.status_code} - {response.text}'
+      )
+      sys.exit(1)
+
   def add_repo_to_runner_group(self, repo_name, runner_group_name):
     repo = self.org.get_repo(repo_name)
     if not repo:
@@ -552,3 +594,13 @@ class GithubSession:
       return False
 
     return True
+
+  def get_teams(self):
+    try:
+      self.teams = self.org.get_teams()
+      self.team_slugs = {team.slug for team in self.teams}
+      log_debug(f'Loaded list of {len(self.team_slugs)} team slugs')
+      return True
+    except Exception as e:
+      log_error(f'Unable to load github teams because: {e}')
+      return None

--- a/src/hmpps/clients/service_catalogue.py
+++ b/src/hmpps/clients/service_catalogue.py
@@ -245,14 +245,14 @@ class ServiceCatalogue:
         headers=self.api_headers,
         timeout=10,
       )
-      if x.status_code == 200:
+      if 200 <= x.status_code < 300:
         log_info(
           f'Successfully deleted record {element_id} from {table.split("/")[-1]}: {x.status_code}'
         )
         success = True
       else:
         log_error(
-          f'Received non-200 response from service catalogue deleting record id {element_id} in {table.split("/")[-1]}: {x.status_code} {x.content}'
+          f'Received non-2xx response from service catalogue deleting record id {element_id} in {table.split("/")[-1]}: {x.status_code} {x.content}'
         )
     except Exception as e:
       log_error(

--- a/uv.lock
+++ b/uv.lock
@@ -209,7 +209,7 @@ wheels = [
 
 [[package]]
 name = "hmpps-python-lib"
-version = "0.0.3"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "gitpython" },

--- a/uv.lock
+++ b/uv.lock
@@ -209,7 +209,7 @@ wheels = [
 
 [[package]]
 name = "hmpps-python-lib"
-version = "0.1.2"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "gitpython" },


### PR DESCRIPTION
This obviously only applies to scripts where a private key is passed into get a token.

A minor change to reduce the likelihood of Github Discovery failures.