### PR TITLE
Fix: get a fresh token on auth rather than on initialisation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hmpps-python-lib"           # distribution name (keeps hyphens)
-version = "0.1.3"
+version = "0.1.4"
 description = "HMPPS shared Python library"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -209,7 +209,7 @@ wheels = [
 
 [[package]]
 name = "hmpps-python-lib"
-version = "0.1.2"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "gitpython" },


### PR DESCRIPTION
Note: this is only required for script that call the class with a private key (eg. Github Discovery).

Essentially it just gets a token just before submitting it for a session, rather than at the beginning of the class.

A couple of other minor fixes as well - tested in dev.